### PR TITLE
Added Visual Studio Code (.vscode/) options directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Visual Studio 2015 cache/options directory
 .vs/
 
+# Visual Studio Code options directory
+.vscode/
+
 # Visual C++ cache files
 ipch/
 *.aps


### PR DESCRIPTION
Decided to add this in the end. Tested by opening folder with .git in VSCode, adding .vscode/tasks.json which is used as a build configuration file and determined that the .gitignore correctly excluded it from marking tasks.json as a new file.